### PR TITLE
Create issue_triage.yml

### DIFF
--- a/.github/workflows/issue_triage.yml
+++ b/.github/workflows/issue_triage.yml
@@ -1,0 +1,27 @@
+name: Issue Triage Automation
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label and assign issue
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['👓 Triage']
+            })
+            github.rest.issues.addAssignees({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              assignees: ['osedoe']
+            })


### PR DESCRIPTION
Issue Triage Automation Implementation

This commit adds a new GitHub Actions workflow that automates the triage process for new issues. Whenever an issue is created, it is now automatically labeled with '👓 Triage' and assigned to @osedoe for initial review.